### PR TITLE
Update Bot.cs

### DIFF
--- a/lib/Bot.cs
+++ b/lib/Bot.cs
@@ -10,6 +10,9 @@ namespace Slackbot
         public string Channel;
         public string[] MentionedUsers = new string[0];
         public string User;
+        
+        [Newtonsoft.Json.JsonExtensionData]
+        public IDictionary<string, object> ExtensionData { get; } = new Dictionary<string, object>();
     }
 
     class SlackData


### PR DESCRIPTION
Add JsonExtension data so developers can access `message` properties without requiring a strongly typed property to be created